### PR TITLE
basic 404 page

### DIFF
--- a/site/src/pages/404.mdx
+++ b/site/src/pages/404.mdx
@@ -1,0 +1,15 @@
+---
+title: 404 - Not Found
+---
+
+import TextLayout from '../components/text-layout.js';
+import { Link } from "gatsby";
+export default TextLayout;
+
+# ~~Potato salad~~ Page not found
+
+It's spooky quiet here...
+
+<Link to="/">
+  <p>Go Back</p>
+</Link>


### PR DESCRIPTION
Adds basic 404 page.

## Couldn't test, requires environment variables to be set
Edit should be small enough for you to see at a glance if it will work, though.

I'm a total noob at actually using .mdx features. I  just copied the frontmatter format and the `TextLayout` import from the other pages.

Tried to get the link to have the same behaviour as the previous button in a browser, but didn't know how to accomplish that in .mdx (do inline functions that call `history.back()` work?).